### PR TITLE
Add more widgets for controlling chart speed option

### DIFF
--- a/src/2dxtra/features/chart_speed.cc
+++ b/src/2dxtra/features/chart_speed.cc
@@ -76,14 +76,20 @@ namespace iidxtra::chart_speed
 
 	using get_sound_entry_fn = sound_entry_t* (*)(int);
 
-	// chart speed multiplier; 1.00 = stock behavior
+	// Current chart speed multiplier; 1.00 = stock behavior
 	float rate = 1.0f;
+
+	// Previously used multiplier by the user; used for the UI
+	float rate_previous = 1.0f;
 
 	// original function
 	void* original_audio_load_fn = nullptr;
 
 	auto reset() -> void
-		{ rate = 1.0f; }
+	{
+		rate = 1.0f;
+		rate_previous = 1.0f;
+	}
 
 	auto mutate(const std::uint8_t player, std::vector<bm2dx::chart_event_t>& buffer) -> void
 	{

--- a/src/2dxtra/features/chart_speed.h
+++ b/src/2dxtra/features/chart_speed.h
@@ -4,8 +4,14 @@
 
 namespace iidxtra::chart_speed
 {
-	// chart speed multiplier; 1.00 = stock behavior
+	constexpr float rate_min = 0.50f;
+	constexpr float rate_max = 3.00f;
+
+	// Current chart speed multiplier; 1.00 = stock behavior
 	extern float rate;
+
+	// Previously used multiplier by the user; used for the UI
+	extern float rate_previous;
 
 	auto reset() -> void;
 	auto mutate(std::uint8_t player, std::vector<bm2dx::chart_event_t>& buffer) -> void;

--- a/src/2dxtra/gui/main_window.cc
+++ b/src/2dxtra/gui/main_window.cc
@@ -1,6 +1,8 @@
 #include <meta.h>
 #include <cmath>
+#include <algorithm>
 #include <string>
+#include <fmt/format.h>
 #include "gui.h"
 #include "loader.h"
 #include "main_window.h"
@@ -18,6 +20,24 @@
 
 namespace iidxtra::gui::main_window
 {
+
+    static auto normalize_rate(float rate) -> float
+    {
+        const auto rounded = std::round(rate * 20.0f) / 20.0f;
+        return std::clamp(rounded, chart_speed::rate_min, chart_speed::rate_max);
+    }
+
+    static auto modify_rate(float rate, bool add) -> float
+    {
+        // Snap to the next 0.05 increment in the pressed direction, even between increments.
+        // Round down and increment, or round up and decrement.
+        const auto scaled = rate * 20.0f;
+        const auto modified = add ?
+            std::floor(scaled) + 1.0f :
+            std::ceil(scaled) - 1.0f;
+        return normalize_rate(modified / 20.0f);
+    }
+
     auto render() -> void
     {
 		// darken game
@@ -158,9 +178,58 @@ namespace iidxtra::gui::main_window
                             ImGui::TextColored({1.f, 0.5f, 0.5f, 1.f}, " *");
                             ImGui::SameLine(300);
                             ImGui::BeginDisabled(!chart_set::switch_enabled);
+
+                            // Slider
                             ImGui::SetNextItemWidth(100);
-                            if (ImGui::SliderFloat("##ChartSpeed", &chart_speed::rate, 0.50f, 3.00f, "x%.2f"))
-                                chart_speed::rate = std::round(chart_speed::rate * 20.0f) / 20.0f;
+                            if (ImGui::SliderFloat("##ChartSpeed",
+                                &chart_speed::rate, chart_speed::rate_min, chart_speed::rate_max, "x%.2f"))
+                            {
+                                chart_speed::rate = normalize_rate(chart_speed::rate);
+                                chart_speed::rate_previous = chart_speed::rate;
+                            }
+
+                            // Decrease
+                            const auto button_size = ImVec2(ImGui::GetFrameHeight(), ImGui::GetFrameHeight());
+                            ImGui::BeginDisabled(chart_speed::rate <= chart_speed::rate_min);
+                            ImGui::SameLine(0, 5.0f);
+                            if (ImGui::Button("-##ChartSpeedDown", button_size))
+                            {
+                                chart_speed::rate = modify_rate(chart_speed::rate, false);
+                                chart_speed::rate_previous = chart_speed::rate;
+                            }
+                            ImGui::EndDisabled();
+
+                            // Increase
+                            ImGui::BeginDisabled(chart_speed::rate >= chart_speed::rate_max);
+                            ImGui::SameLine(0, 5.0f);
+                            if (ImGui::Button("+##ChartSpeedUp", button_size))
+                            {
+                                chart_speed::rate = modify_rate(chart_speed::rate, true);
+                                chart_speed::rate_previous = chart_speed::rate;
+                            }
+                            ImGui::EndDisabled();
+
+                            // Toggle buttons
+                            if (chart_speed::rate == 1.0f)
+                            {
+                                if (chart_speed::rate_previous != 1.0f)
+                                {
+                                    const auto label = fmt::format("x{:.2f}##ChartSpeedRestore", chart_speed::rate_previous);
+                                    ImGui::SameLine(0, 5.0f);
+                                    if (ImGui::Button(label.c_str()))
+                                        chart_speed::rate = chart_speed::rate_previous;
+                                }
+                            }
+                            else
+                            {
+                                ImGui::SameLine(0, 5.0f);
+                                if (ImGui::Button("x1.00##ChartSpeedReset"))
+                                {
+                                    chart_speed::rate_previous = chart_speed::rate;
+                                    chart_speed::rate = 1.0f;
+                                }
+                            }
+
                             ImGui::EndDisabled();
                         }
                         ImGui::PopStyleVar();


### PR DESCRIPTION
Adds:

* `-` button to decrement by 0.05
* `+` button to increment by 0.05
* Dynamic toggle button that resets to 1x or restores previous value.