### PR TITLE
Option to replace FAST/SLOW display with millisecond timing values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCE_FILES
     src/2dxtra/hooks/card_out_hook.cc
     src/2dxtra/hooks/play_field_load_hook.cc
     src/2dxtra/hooks/judge_timing_hook.cc
+    src/2dxtra/hooks/fast_slow_hook.cc
     src/2dxtra/hooks/attract_randomizer_hook.cc
     src/2dxtra/features/cn_transformer.cc
     src/2dxtra/features/keysound_switch.cc
@@ -81,6 +82,7 @@ set(SOURCE_FILES
     src/2dxtra/features/scratch_swap.cc
     src/2dxtra/features/play_visuals.cc
     src/2dxtra/features/timing_modifier.cc
+    src/2dxtra/features/fast_slow_display.cc
     src/2dxtra/features/autoretry.cc
     res/2dxtra.def
     res/2dxtra.rc

--- a/src/2dxtra/features/fast_slow_display.cc
+++ b/src/2dxtra/features/fast_slow_display.cc
@@ -1,0 +1,120 @@
+#include <fmt/format.h>
+#include <cmath>
+#include "../hooks/fast_slow_hook.h"
+#include "fast_slow_display.h"
+
+namespace iidxtra::fast_slow_display
+{
+    auto enabled = false;
+
+    auto update() -> void
+    {
+        fast_slow_hook::set_enabled(enabled);
+    }
+
+    auto reset() -> void
+    {
+        enabled = false;
+        update();
+    }
+
+    // Determine if zero, fast, or slow.
+    auto timing_t::get_polarity() const -> polarity
+    {
+        if (!std::isfinite(milliseconds) ||
+            std::abs(milliseconds) > 999.0f ||
+            milliseconds == 0.0f) {
+            return polarity::zero;
+        }
+
+        return milliseconds < 0 ? polarity::fast : polarity::slow;
+    }
+
+    // Get formatted string to display for millisecond timing.
+    auto format_fastslow_ms(const float milliseconds) -> std::array<char, 7>
+    {
+        // +999.9 (6 characters + null terminator)
+        auto result = std::array<char, 7> {};
+
+        // Sanity check bounds.
+        if (!std::isfinite(milliseconds) || std::abs(milliseconds) > 999.0f) {
+            return result;
+        }
+
+        // Tenths of milliseconds (8.3ms --> 83).
+        const auto tenths = static_cast<std::uint32_t>(std::round(std::abs(milliseconds) * 10.0f));
+
+        // Frame perfect timing - nothing to show.
+        if (tenths == 0) {
+            return result;
+        }
+
+        // Format text.
+        fmt::format_to_n(
+            result.data(),
+            result.size() - 1,
+            "{}.{}",
+            tenths / 10,
+            tenths % 10);
+
+        return result;
+    }
+
+    // Reset player state.
+    auto display_cache_t::reset(const int player, const std::uintptr_t owner) -> void
+    {
+        if (player >= 0 && player < 2) {
+            players_[player] = player_display_t { owner, {}, {}, {} };
+        }
+    }
+
+    auto display_cache_t::update(const int player, const std::uintptr_t owner, const int code,
+                                 const bool scratch, const timing_t timing) -> void
+    {
+        // Sanity check bounds.
+        if (player != 0 && player != 1) {
+            return;
+        }
+
+        if (players_[player].owner != owner) {
+            reset(player, owner);
+        }
+
+        // hold for charge note
+        if (code == 12) {
+            return;
+        }
+
+        auto& display = players_[player];
+
+        // Update combined f/s display.
+        display.combined = timing;
+
+        // Update separated f/s display.
+        if (scratch) {
+            display.scratch = display.combined;
+        } else {
+            display.keys = display.combined;
+        }
+    }
+
+    // Get the current timing for the given player and display mode.
+    auto display_cache_t::get(const int player, const std::uintptr_t owner, const bool separate,
+                              const bool scratch) const -> timing_t
+    {
+        // Sanity check bounds.
+        if (player != 0 && player != 1 ||
+            players_[player].owner != owner)
+            return {};
+
+        auto const& display = players_[player];
+
+        // Combined f/s display.
+        if (!separate) {
+            return display.combined;
+        }
+
+        // Separated f/s display.
+        return scratch ? display.scratch : display.keys;
+    }
+}

--- a/src/2dxtra/features/fast_slow_display.h
+++ b/src/2dxtra/features/fast_slow_display.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace iidxtra::fast_slow_display
+{
+    extern bool enabled;
+
+    auto update() -> void;
+    auto reset() -> void;
+
+    enum class polarity { zero, fast, slow };
+
+    struct timing_t
+    {
+        float milliseconds = 0.0f;
+
+        auto get_polarity() const -> polarity;
+    };
+
+    struct player_display_t
+    {
+        // which player?
+        std::uintptr_t owner = 0;
+        timing_t combined;
+        timing_t keys;
+        timing_t scratch;
+    };
+
+    class display_cache_t
+    {
+    public:
+        auto reset(int player, std::uintptr_t owner) -> void;
+        auto update(int player, std::uintptr_t owner, int code, bool scratch, timing_t timing) -> void;
+        auto get(int player, std::uintptr_t owner, bool separate, bool scratch) const -> timing_t;
+
+    private:
+        std::array<player_display_t, 2> players_ {};
+    };
+
+    auto format_fastslow_ms(float milliseconds) -> std::array<char, 7>;
+}

--- a/src/2dxtra/game.h
+++ b/src/2dxtra/game.h
@@ -147,11 +147,14 @@ namespace bm2dx
     {
         std::uint8_t pad_0000[64]; //0x0000
 		std::int32_t spacing; //0x0040
-		std::uint8_t pad_0044[12]; //0x0044
-		std::int32_t h_align; //0x0050
-        std::int32_t v_align; //0x0054
-        std::uint8_t pad_0058[256]; //0x0058 (extra space for text)
+		std::uint8_t pad_0044[16]; //0x0044
+		std::int32_t h_align; //0x0054
+        std::int32_t v_align; //0x0058
+        std::uint8_t pad_005c[252]; //0x005C (extra space for text)
     };
+    static_assert(offsetof(text_props_t, h_align) == 0x54);
+    static_assert(offsetof(text_props_t, v_align) == 0x58);
+    static_assert(sizeof(text_props_t) == 0x158);
 
 	struct random_data_t
 	{

--- a/src/2dxtra/gui/main_window.cc
+++ b/src/2dxtra/gui/main_window.cc
@@ -17,6 +17,8 @@
 #include "../features/chart_speed.h"
 #include "../features/keysound_switch.h"
 #include "../features/play_visuals.h"
+#include "../features/fast_slow_display.h"
+#include "../hooks/fast_slow_hook.h"
 
 namespace iidxtra::gui::main_window
 {
@@ -337,6 +339,20 @@ namespace iidxtra::gui::main_window
                         }
                         ImGui::PopStyleVar();
                         ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f}, "Hide the flashing blue bar above the keys");
+                    }
+
+                    {
+                        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, -5.0f));
+                        {
+                            ImGui::BeginDisabled(!fast_slow_hook::available() || bm2dx::play_session->in_gameplay);
+                            ImGui::Text("FAST/SLOW ms");
+                            ImGui::SameLine(300);
+                            if (ImGui::Checkbox("##MillisecondFastSlow", &fast_slow_display::enabled))
+                                fast_slow_display::update();
+                            ImGui::EndDisabled();
+                        }
+                        ImGui::PopStyleVar();
+                        ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f}, "Replace FAST/SLOW with millisecond values");
                     }
                 }
 

--- a/src/2dxtra/hooks/fast_slow_hook.cc
+++ b/src/2dxtra/hooks/fast_slow_hook.cc
@@ -1,0 +1,486 @@
+#include <MinHook.h>
+#include <fmt/format.h>
+#include <cstring>
+#include <mutex>
+#include <string_view>
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+#include "../game.h"
+#include "../features/fast_slow_display.h"
+#include "fast_slow_hook.h"
+
+namespace iidxtra::fast_slow_hook
+{
+    // Replace FAST/SLOW sprites with millisecond text rendered by us:
+    //
+    // 1. judge_apply_hook_fn captures the millisecond timing value.
+    // 2. judge_display_hook_fn updates our stored timing to match the game's judgment.
+    // 3. judge_draw_fs_keys_hook_fn & judge_draw_fs_sc_hook_fn call draw_indicator
+    //    to prepare the timing text, then call the game's original draw function.
+    // 4. sprite_draw_hook_fn receives the sprite's x/y coordinates, hides the
+    //    FAST/SLOW sprite, and draws our text in its place.
+
+    using fast_slow_display::polarity;
+    using fast_slow_display::timing_t;
+
+    // Native candidate record; the judgment context starts with eight records per player.
+    struct judge_apply_hook_context_t
+    {
+        // timing value in milliseconds
+        float milliseconds;
+        std::byte reserved_04[4];
+        // pointer to in-game note; used to check if judgement is valid (has note)
+        void* note;
+    };
+    static_assert(sizeof(judge_apply_hook_context_t) == 16);
+    static_assert(offsetof(judge_apply_hook_context_t, note) == 8);
+
+    // context object passed to judge_display_hook_fn.
+    struct alignas(8) judge_display_hook_context_t
+    {
+        std::byte reserved_00[8];
+
+        // p1 (0) or p2 (1)
+        int player;
+
+        std::byte reserved_0c[20];
+
+        // code:
+        //   4 = PGREAT
+        //   3 = FAST
+        //   5 = SLOW
+        //   8 = MISS
+        int combined_code;
+
+        std::byte reserved_24[12];
+        int key_code;
+        std::byte reserved_34[4];
+        int scratch_code;
+        std::byte reserved_3c[4];
+    };
+    static_assert(sizeof(judge_display_hook_context_t) == 64);
+    static_assert(offsetof(judge_display_hook_context_t, player) == 8);
+    static_assert(offsetof(judge_display_hook_context_t, combined_code) == 32);
+    static_assert(offsetof(judge_display_hook_context_t, key_code) == 48);
+    static_assert(offsetof(judge_display_hook_context_t, scratch_code) == 56);
+
+    // Native function signatures and original functions populated by MinHook.
+    using judge_apply_t = int (*)(void* context, int player, int grade, int lane, int score_index);
+    using judge_display_t = std::intptr_t (*)(void* display, int code, int combo, bool scratch);
+    using draw_indicator_t = void (*)(void* display);
+    using judge_display_init_t = std::intptr_t (*)(void* display, int player, int mode);
+    using sprite_draw_t = void* (*)(void* manager, const char* name, int horizontal, int vertical,
+                                   float scale, unsigned int layer, unsigned int flags);
+    using init_text_t = bm2dx::text_props_t* (*)(bm2dx::text_props_t* properties);
+    using text_render_t = void (*)(int font, int horizontal, int vertical, int layer,
+                                  bm2dx::text_props_t* properties, const char* text);
+
+    judge_apply_t original_judge_apply_fn = nullptr;
+    judge_display_t original_judge_display_fn = nullptr;
+    draw_indicator_t original_judge_draw_fs_keys_fn = nullptr;
+    draw_indicator_t original_judge_draw_fs_sc_fn = nullptr;
+    judge_display_init_t original_judge_display_init_fn = nullptr;
+    sprite_draw_t original_sprite_draw_fn = nullptr;
+
+    // Shared timing and enable state are accessed from both game hooks and the menu.
+    auto state_mutex = std::mutex {};
+    auto cache = fast_slow_display::display_cache_t {};
+    auto display_enabled = false;
+    auto installed = false;
+
+    auto is_enabled() -> bool
+    {
+        const auto lock = std::lock_guard { state_mutex };
+        return display_enabled;
+    }
+
+    // Stores the pending judgment for next draw call.
+    struct pending_judgment_t
+    {
+        int player = -1;
+        bool scratch = false;
+        timing_t timing;
+    };
+    thread_local auto pending = pending_judgment_t {};
+
+    // Temporary state for the next draw function.
+    struct render_context_t
+    {
+        timing_t timing;
+        std::array<char, 7> text {};
+        bool miss = false;
+    };
+    thread_local auto rendering = render_context_t {};
+
+    // Helper routine for reading bytes from base address + offset.
+    template<typename Value>
+    auto read(const void* object, const std::size_t offset = 0) -> Value
+    {
+        auto value = Value {};
+        std::memcpy(&value, static_cast<const std::byte*>(object) + offset, sizeof(value));
+        return value;
+    }
+
+    // Determines if a user has separated fast/slow display option enabled.
+    auto separate_scratch(const int player) -> bool
+    {
+        constexpr auto profiles_offset = 0x08;
+        constexpr auto profile_stride = 0xac;
+        constexpr auto separate_scratch_offset = 0x64;
+
+        // Profiles 0/1 are P1/P2 single play.
+        // Profile 2 is double play.
+        const auto profile = bm2dx::state->play_style != 0 ? 2 : player;
+
+        // A value of 1 selects independent key/scratch timing.
+        const auto game_options = reinterpret_cast<void* (*)()>(bm2dx::addr->GET_PLAY_OPTIONS_FN)();
+
+        return read<int>(game_options, profiles_offset + profile_stride * profile + separate_scratch_offset) == 1;
+    }
+
+    // Called to reset judge display for a player.
+    auto judge_display_init_hook_fn(void* display, const int player, const int mode) -> std::intptr_t
+    {
+        {
+            const auto lock = std::lock_guard { state_mutex };
+            cache.reset(player, reinterpret_cast<std::uintptr_t>(display));
+        }
+        return original_judge_display_init_fn(display, player, mode);
+    }
+
+    // Timing value must be captured here, before the original call updates the display.
+    auto judge_apply_hook_fn(void* context, const int player, const int grade,
+                             const int lane, const int score_index) -> int
+    {
+#ifdef _MSC_VER
+        const auto caller = static_cast<std::uint8_t*>(_ReturnAddress());
+#else
+        const auto caller = static_cast<std::uint8_t*>(__builtin_return_address(0));
+#endif
+
+        // Load the saved pending value
+        const auto saved_pending = pending;
+        pending = {};
+
+        try
+        {
+            const auto& addresses = *bm2dx::addr;
+
+            if (is_enabled() &&
+                player >= 0 && player < 2 &&
+                lane >= 0 && lane < 8 &&
+                grade >= 0 && grade <= 8 &&
+                (caller == addresses.JUDGE_PRESS_RETURN || caller == addresses.JUDGE_RELEASE_RETURN))
+            {
+                // read the candidate judgment context for this lane and player
+                const auto candidate = read<judge_apply_hook_context_t>(
+                    context, sizeof(judge_apply_hook_context_t) * (lane + 8 * player));
+                if (candidate.note)
+                    pending = { player, lane == 7, { candidate.milliseconds } };
+            }
+
+            // call into the original judgment apply function
+            const auto result = original_judge_apply_fn(context, player, grade, lane, score_index);
+            pending = saved_pending;
+            return result;
+        }
+        catch (...)
+        {
+            pending = saved_pending;
+            throw;
+        }
+    }
+
+    // Hook for judge display.
+    // This doesn't draw anything, but it is hooked store the timing value for later use by draw function.
+    auto judge_display_hook_fn(void* display, const int code, const int combo,
+                               const bool scratch) -> std::intptr_t
+    {
+        const auto result = original_judge_display_fn(display, code, combo, scratch);
+        const auto player = read<judge_display_hook_context_t>(display).player;
+
+        const auto lock = std::lock_guard { state_mutex };
+        auto timing = timing_t {};
+        if (display_enabled && pending.player == player && pending.scratch == scratch)
+            timing = pending.timing;
+
+        cache.update(player, reinterpret_cast<std::uintptr_t>(display), code, scratch, timing);
+        return result;
+    }
+
+    // The game still decides whether and where to draw an indicator. We prepare the text here,
+    // then let its draw function reach sprite_draw_hook_fn with the native position and layer.
+    auto draw_indicator(void* display, const bool scratch, const draw_indicator_t original) -> void
+    {
+        const auto saved_rendering = rendering;
+        rendering = {};
+
+        try
+        {
+            // if the feature is disabled, call the original
+            if (!is_enabled())
+            {
+                original(display);
+                rendering = saved_rendering;
+                return;
+            }
+
+            auto local_display = read<judge_display_hook_context_t>(display);
+            auto pgreat = false;
+            if (local_display.player >= 0 && local_display.player < 2)
+            {
+                const auto separate = separate_scratch(local_display.player);
+                auto* displayed_code = &local_display.combined_code;
+                if (scratch)
+                    displayed_code = &local_display.scratch_code;
+                else if (separate)
+                    displayed_code = &local_display.key_code;
+
+                const auto code = *displayed_code;
+                {
+                    const auto lock = std::lock_guard { state_mutex };
+                    rendering.timing = cache.get(local_display.player, reinterpret_cast<std::uintptr_t>(display),
+                                                 separate, scratch);
+                }
+
+                if (code == 8)
+                {
+                    // For complete misses, display 'miss'.
+                    rendering.miss = true;
+                    rendering.timing = {};
+                    rendering.text = { 'm', 'i', 's', 's', '\0' };
+                }
+                else
+                {
+                    // Otherwise, format the text for millisecond timing.
+                    rendering.text = fast_slow_display::format_fastslow_ms(rendering.timing.milliseconds);
+                }
+
+                if (code == 4 && rendering.text[0] != '\0')
+                {
+                    // Code 4 (PGREAT) normally emits no FAST/SLOW sprite for us to replace.
+                    // Change only our copy to code 3 (FAST) or 5 (SLOW), making the native draw
+                    // function emit that sprite while leaving the game's real PGREAT untouched.
+                    *displayed_code = rendering.timing.get_polarity() == polarity::slow ? 5 : 3;
+                    pgreat = true;
+                }
+            }
+
+            if (rendering.text[0] == '\0')
+            {
+                rendering = saved_rendering;
+                return;
+            }
+
+            if (pgreat)
+            {
+                // Call the original but convince it to still display f/s indicator even for pgreat
+                original(&local_display);
+            }
+            else
+            {
+                // Call the original.
+                original(display);
+            }
+
+            // Restore the original rendering state.
+            rendering = saved_rendering;
+        }
+        catch (...)
+        {
+            rendering = saved_rendering;
+            throw;
+        }
+    }
+
+    auto judge_draw_fs_keys_hook_fn(void* display) -> void
+    {
+        draw_indicator(display, false, original_judge_draw_fs_keys_fn);
+    }
+
+    auto judge_draw_fs_sc_hook_fn(void* display) -> void
+    {
+        draw_indicator(display, true, original_judge_draw_fs_sc_fn);
+    }
+
+    auto get_text_color(const bool fast, const bool scratch) -> const char*
+    {
+        // slightly brighter versions for scratch
+        if (scratch) {
+            return fast ? "99e6ffff" : "ffb3b3ff";
+        }
+
+        // same color as fast/slow sprites
+        return fast ? "3399ffff" : "ff3333ff";
+    }
+
+    auto draw_text(int horizontal, int vertical, const unsigned int layer, const char* text,
+                   const int width, const int height, const bool fast, const bool scratch,
+                   const bool miss) -> void
+    {
+        // Font 3 is DFG Heisei Gothic W7 at 16 pixels, also used by bottom text like FREE PLAY.
+        constexpr auto font = 3;
+
+        // Five characters plus boldness and border occupy 63 pixels
+        // compare to 66-pixel width of FAST / SLOW sprites.
+        constexpr auto cell_width = 12;
+
+        // This ends up being 24px tall, which is identical to FAST / SLOW sprites.
+        constexpr auto cell_height = 22;
+
+        constexpr auto border_radius = 1;
+        constexpr auto bold_offset = 1;
+
+        auto properties = bm2dx::text_props_t {};
+
+        // ask game to init text
+        static auto init_text = reinterpret_cast<init_text_t>(bm2dx::addr->TEXT_INIT_FN);
+        init_text(&properties);
+
+        auto content = std::string {};
+        if (miss)
+        {
+            // Center the whole word in the sprite area, with all letters on a shared baseline.
+            properties.h_align = 1;
+            properties.v_align = 1;
+            horizontal += (width - bold_offset) / 2;
+            vertical += height / 2;
+            content = text;
+        }
+        else
+        {
+            const auto text_width = static_cast<int>(std::strlen(text)) * cell_width;
+            const auto total_width = text_width + bold_offset + 2 * border_radius;
+            const auto total_height = cell_height + 2 * border_radius;
+
+            // Right-align fixed-width cells so the decimal point stays put as integer digits change.
+            horizontal += width - total_width + border_radius;
+            vertical += (height - total_height) / 2 + border_radius;
+            content = fmt::format("<tt {} {}>{}</tt>", cell_width, cell_height, text);
+        }
+
+        // Format string.
+        const auto label = fmt::format(
+            "<color {}><scale 1.0 1.0>{}</scale></color>",
+            get_text_color(fast, scratch),
+            content);
+        const auto border = fmt::format(
+            "<color 000000ff><scale 1.0 1.0>{}</scale></color>", content);
+
+        static auto text_render = reinterpret_cast<text_render_t>(bm2dx::addr->TEXT_RENDER_FN);
+        for (int offset_y = -border_radius; offset_y <= border_radius; ++offset_y)
+        {
+            for (int offset_x = -border_radius; offset_x <= bold_offset + border_radius; ++offset_x)
+            {
+                if (offset_y == 0 && offset_x >= 0 && offset_x <= bold_offset)
+                    continue;
+
+                text_render(font, horizontal + offset_x, vertical + offset_y,
+                            static_cast<int>(layer), &properties, border.c_str());
+            }
+        }
+        text_render(font, horizontal, vertical, static_cast<int>(layer), &properties, label.c_str());
+        text_render(font, horizontal + bold_offset, vertical, static_cast<int>(layer), &properties, label.c_str());
+    }
+
+    // Replace only FAST/SLOW sprites emitted within the current indicator draw call.
+    auto sprite_draw_hook_fn(void* manager, const char* name, const int horizontal, const int vertical,
+                             const float scale, const unsigned int layer, const unsigned int flags) -> void*
+    {
+        const auto sprite = original_sprite_draw_fn(manager, name, horizontal, vertical, scale, layer, flags);
+        if (!sprite || !name || rendering.text[0] == '\0')
+            return sprite;
+
+        const auto asset = std::string_view { name };
+        if (asset != "fast" && asset != "slow" && asset != "s_fast" && asset != "s_slow")
+            return sprite;
+
+        const auto vtable = read<std::uintptr_t*>(sprite);
+        const auto set_visible = reinterpret_cast<void (*)(void*, bool)>(vtable[5]);
+        const auto get_dimensions = reinterpret_cast<std::intptr_t (*)(void*, int*, int*)>(vtable[39]);
+
+        // Hide the original before drawing the replacement. Even if text drawing
+        // fails, enabled mode must not briefly show the native FAST/SLOW label instead.
+        set_visible(sprite, false);
+
+        auto width = 0;
+        auto height = 0;
+        get_dimensions(sprite, &width, &height);
+        draw_text(horizontal, vertical, layer, rendering.text.data(), width, height,
+                  rendering.timing.get_polarity() == polarity::fast, asset.starts_with("s_"), rendering.miss);
+
+        return sprite;
+    }
+
+    // Menu-facing controls. Toggling starts with an empty timing cache.
+    auto available() -> bool
+    {
+        const auto lock = std::lock_guard { state_mutex };
+        return installed;
+    }
+
+    auto set_enabled(const bool value) -> void
+    {
+        const auto lock = std::lock_guard { state_mutex };
+        display_enabled = installed && value;
+        cache = {};
+    }
+
+    auto install_hook() -> void
+    {
+        // Create the complete hook chain here; common startup enables it with the other hooks.
+        const auto& addresses = *bm2dx::addr;
+        const auto targets = std::array {
+            addresses.JUDGE_APPLY_FN,
+            addresses.JUDGE_DISPLAY_FN,
+            addresses.JUDGE_DRAW_FS_KEYS_FN,
+            addresses.JUDGE_DRAW_FS_SC_FN,
+            addresses.JUDGE_DISPLAY_INIT_FN,
+            addresses.SPRITE_DRAW_FN
+        };
+
+        const auto results = std::array {
+            MH_CreateHook(
+                addresses.JUDGE_APPLY_FN,
+                reinterpret_cast<LPVOID>(judge_apply_hook_fn),
+                reinterpret_cast<LPVOID*>(&original_judge_apply_fn)),
+            MH_CreateHook(
+                addresses.JUDGE_DISPLAY_FN,
+                reinterpret_cast<LPVOID>(judge_display_hook_fn),
+                reinterpret_cast<LPVOID*>(&original_judge_display_fn)),
+            MH_CreateHook(
+                addresses.JUDGE_DRAW_FS_KEYS_FN,
+                reinterpret_cast<LPVOID>(judge_draw_fs_keys_hook_fn),
+                reinterpret_cast<LPVOID*>(&original_judge_draw_fs_keys_fn)),
+            MH_CreateHook(
+                addresses.JUDGE_DRAW_FS_SC_FN,
+                reinterpret_cast<LPVOID>(judge_draw_fs_sc_hook_fn),
+                reinterpret_cast<LPVOID*>(&original_judge_draw_fs_sc_fn)),
+            MH_CreateHook(
+                addresses.JUDGE_DISPLAY_INIT_FN,
+                reinterpret_cast<LPVOID>(judge_display_init_hook_fn),
+                reinterpret_cast<LPVOID*>(&original_judge_display_init_fn)),
+            MH_CreateHook(
+                addresses.SPRITE_DRAW_FN,
+                reinterpret_cast<LPVOID>(sprite_draw_hook_fn),
+                reinterpret_cast<LPVOID*>(&original_sprite_draw_fn))
+        };
+
+        // Capture, cache updates, and sprite replacement must be installed together. If any
+        // creation failed, remove only hooks created by this attempt and keep the option disabled.
+        for (const auto status : results)
+        {
+            if (status != MH_OK)
+            {
+                for (std::size_t index = 0; index < targets.size(); ++index)
+                    if (results[index] == MH_OK)
+                        MH_RemoveHook(targets[index]);
+                return;
+            }
+        }
+
+        const auto lock = std::lock_guard { state_mutex };
+        installed = true;
+    }
+}

--- a/src/2dxtra/hooks/fast_slow_hook.h
+++ b/src/2dxtra/hooks/fast_slow_hook.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace iidxtra::fast_slow_hook
+{
+    auto install_hook() -> void;
+    auto available() -> bool;
+    auto set_enabled(bool value) -> void;
+}

--- a/src/2dxtra/hooks/reset_state_hook.cc
+++ b/src/2dxtra/hooks/reset_state_hook.cc
@@ -18,6 +18,7 @@
 #include "../features/autoretry.h"
 #include "reset_state_hook.h"
 #include "score_invalidator_hook.h"
+#include "../features/fast_slow_display.h"
 
 namespace iidxtra::reset_state_hook
 {
@@ -55,6 +56,7 @@ namespace iidxtra::reset_state_hook
             cn_transformer::reset();
             play_visuals::reset();
             timing_modifier::reset();
+            fast_slow_display::reset();
             autoretry::reset();
         }
 

--- a/src/2dxtra/init.cc
+++ b/src/2dxtra/init.cc
@@ -20,6 +20,7 @@
 #include "hooks/card_out_hook.h"
 #include "hooks/play_field_load_hook.h"
 #include "hooks/judge_timing_hook.h"
+#include "hooks/fast_slow_hook.h"
 #include "hooks/attract_randomizer_hook.h"
 #include "features/autoplay.h"
 #include "features/unrandomizer.h"
@@ -65,6 +66,7 @@ namespace iidxtra
         autoretry::install_hook();
         play_field_load_hook::install_hook();
         judge_timing_hook::install_hook();
+		fast_slow_hook::install_hook();
 		autoplay::install_hook();
 		unrandomizer::install_hook();
 		attract_randomizer_hook::install_hook();

--- a/src/2dxtra/offsets.h.in
+++ b/src/2dxtra/offsets.h.in
@@ -72,6 +72,15 @@ struct offsets
     std::uint8_t* WNDPROC_FN;             // "PropClassWindowProc" for the game window
     std::uint8_t* TIMING_HOOK_FN;         // last chance to change the judge windows before play
     std::uint8_t* ATTRACT_SELECT_FN;      // picks the next attract demo chart
+    std::uint8_t* GET_PLAY_OPTIONS_FN;    // returns player options
+    std::uint8_t* SPRITE_DRAW_FN;         // creates a named sprite at its native position and layer
+    std::uint8_t* JUDGE_APPLY_FN;         // applies a note judgment; used to obtain ms timing info
+    std::uint8_t* JUDGE_DISPLAY_FN;       // updates judge, combo, fast/slow to be drawn
+    std::uint8_t* JUDGE_DRAW_FS_KEYS_FN;  // draws FAST/SLOW indicator for keys (or both if combined)
+    std::uint8_t* JUDGE_DRAW_FS_SC_FN;    // draws the separate scratch FAST/SLOW indicator
+    std::uint8_t* JUDGE_DISPLAY_INIT_FN;  // initialises one player's judgment display state
+    std::uint8_t* JUDGE_PRESS_RETURN;     // return address of general timing calculation
+    std::uint8_t* JUDGE_RELEASE_RETURN;   // return address of CN release timing calculation
 
     // offsets: variables
     std::uint8_t* GAME_MODEL;             // the mutable ea3 model string ("***:*:*:*:**********")

--- a/src/2dxtra/offsets/2025082500-010.cc
+++ b/src/2dxtra/offsets/2025082500-010.cc
@@ -64,6 +64,16 @@ versions.push_back({
     .TIMING_HOOK_FN           = base + 0x082e340, // jump-table dispatcher that installs the judge windows
     .ATTRACT_SELECT_FN        = base + 0x08b1610, // picks the next attract demo chart
 
+    .GET_PLAY_OPTIONS_FN      = base + 0x0897300, // returns player options
+    .SPRITE_DRAW_FN           = base + 0x033cf60, // creates a named sprite at its native position and layer
+    .JUDGE_APPLY_FN           = base + 0x082dcd0, // applies a note judgment; used to obtain ms timing info
+    .JUDGE_DISPLAY_FN         = base + 0x09291d0, // updates judge, combo, fast/slow to be drawn
+    .JUDGE_DRAW_FS_KEYS_FN    = base + 0x0928910, // draws FAST/SLOW indicator for keys (or both if combined)
+    .JUDGE_DRAW_FS_SC_FN      = base + 0x0928c00, // draws the separate scratch FAST/SLOW indicator
+    .JUDGE_DISPLAY_INIT_FN    = base + 0x0928f70, // initialises one player's judgment display state
+    .JUDGE_PRESS_RETURN       = base + 0x082e947, // return address of general timing calculation
+    .JUDGE_RELEASE_RETURN     = base + 0x082d8aa, // return address of CN release timing calculation
+
     // offsets: data
     .GAME_MODEL               = base + 0x1076270, // the mutable copy of the ea3 model string
     .GAME_STATE               = base + 0xa9fa900, // state block; p1_active/p2_active at +0x10/+0x14 pin it down


### PR DESCRIPTION

This replaces FAST / SLOW sprites with millisecond values rendered by the DLL.

The format is `000.0` in units of mlliseconds. The smallest value is `8.3` and the largest is 100-something milliseconds so this should be sufficient.

If the user has the option enabled to display separate fast/slow indicator for scratches, this works too. It'll be rendered with slightly brighter color.

Subtle behavior difference to note: this will show the timing value even if the judgement is PGREAT, unless the input was frame perfect (0.0ms).