### PR TITLE
Minor fixes for ms timing option

### DIFF
--- a/src/2dxtra/features/fast_slow_display.cc
+++ b/src/2dxtra/features/fast_slow_display.cc
@@ -7,16 +7,16 @@
 
 namespace iidxtra::fast_slow_display
 {
-    auto mode = mode_t::off;
+    auto options = options_t {};
 
     auto update() -> void
     {
-        fast_slow_hook::set_mode(mode);
+        fast_slow_hook::set_options(options);
     }
 
     auto reset() -> void
     {
-        mode = mode_t::off;
+        options = {};
         update();
     }
 

--- a/src/2dxtra/features/fast_slow_display.cc
+++ b/src/2dxtra/features/fast_slow_display.cc
@@ -1,4 +1,5 @@
 #include <fmt/format.h>
+#include <algorithm>
 #include <cmath>
 #include "../hooks/fast_slow_hook.h"
 #include "../judgment.h"
@@ -23,7 +24,6 @@ namespace iidxtra::fast_slow_display
     auto timing_t::get_polarity() const -> polarity
     {
         if (!std::isfinite(milliseconds) ||
-            std::abs(milliseconds) > 999.0f ||
             milliseconds == 0.0f) {
             return polarity::zero;
         }
@@ -38,12 +38,13 @@ namespace iidxtra::fast_slow_display
         auto result = std::array<char, 7> {};
 
         // Sanity check bounds.
-        if (!std::isfinite(milliseconds) || std::abs(milliseconds) > 999.0f) {
+        if (!std::isfinite(milliseconds)) {
             return result;
         }
 
         // Tenths of milliseconds (8.3ms --> 83).
-        const auto tenths = static_cast<std::uint32_t>(std::round(std::abs(milliseconds) * 10.0f));
+        const auto magnitude = std::min(std::abs(milliseconds), 999.9f);
+        const auto tenths = static_cast<std::uint32_t>(std::round(magnitude * 10.0f));
 
         // Frame perfect timing - nothing to show.
         if (tenths == 0) {

--- a/src/2dxtra/features/fast_slow_display.cc
+++ b/src/2dxtra/features/fast_slow_display.cc
@@ -1,20 +1,21 @@
 #include <fmt/format.h>
 #include <cmath>
 #include "../hooks/fast_slow_hook.h"
+#include "../judgment.h"
 #include "fast_slow_display.h"
 
 namespace iidxtra::fast_slow_display
 {
-    auto enabled = false;
+    auto mode = mode_t::off;
 
     auto update() -> void
     {
-        fast_slow_hook::set_enabled(enabled);
+        fast_slow_hook::set_mode(mode);
     }
 
     auto reset() -> void
     {
-        enabled = false;
+        mode = mode_t::off;
         update();
     }
 
@@ -81,7 +82,7 @@ namespace iidxtra::fast_slow_display
         }
 
         // hold for charge note
-        if (code == 12) {
+        if (code == bm2dx::judge_display_code::charge_hold) {
             return;
         }
 

--- a/src/2dxtra/features/fast_slow_display.h
+++ b/src/2dxtra/features/fast_slow_display.h
@@ -5,7 +5,9 @@
 
 namespace iidxtra::fast_slow_display
 {
-    extern bool enabled;
+    enum class mode_t { off, great_and_below, always };
+
+    extern mode_t mode;
 
     auto update() -> void;
     auto reset() -> void;
@@ -15,6 +17,7 @@ namespace iidxtra::fast_slow_display
     struct timing_t
     {
         float milliseconds = 0.0f;
+        bool excessive_poor = false;
 
         auto get_polarity() const -> polarity;
     };

--- a/src/2dxtra/features/fast_slow_display.h
+++ b/src/2dxtra/features/fast_slow_display.h
@@ -5,14 +5,18 @@
 
 namespace iidxtra::fast_slow_display
 {
-    enum class mode_t {
-        off,
-        great_and_below,
-        great_and_below_shifted,
-        always
+    struct options_t
+    {
+        bool show_milliseconds = false;
+        bool show_pgreat = false;
+
+        auto enabled() const -> bool
+        {
+            return show_milliseconds || show_pgreat;
+        }
     };
 
-    extern mode_t mode;
+    extern options_t options;
 
     auto update() -> void;
     auto reset() -> void;
@@ -23,6 +27,10 @@ namespace iidxtra::fast_slow_display
     {
         float milliseconds = 0.0f;
         bool excessive_poor = false;
+        bool measured = false;
+
+        // ticks [0, 1], never show f/s indicator
+        bool within_dead_zone = false;
 
         auto get_polarity() const -> polarity;
     };

--- a/src/2dxtra/features/fast_slow_display.h
+++ b/src/2dxtra/features/fast_slow_display.h
@@ -5,7 +5,12 @@
 
 namespace iidxtra::fast_slow_display
 {
-    enum class mode_t { off, great_and_below, always };
+    enum class mode_t {
+        off,
+        great_and_below,
+        great_and_below_shifted,
+        always
+    };
 
     extern mode_t mode;
 

--- a/src/2dxtra/gui/main_window.cc
+++ b/src/2dxtra/gui/main_window.cc
@@ -344,8 +344,8 @@ namespace iidxtra::gui::main_window
                     {
                         auto const options = std::vector<std::tuple<std::string, std::string>> {
                             {"Off", "Use regular FAST/SLOW sprites"},
-                            {"<PGREAT", "Show milliseconds for GREAT and below"},
-                            {"Always", "Show milliseconds for all judgments except 0.0ms"},
+                            {"<PGREAT", "Show ms for GREAT and below"},
+                            {"Always", "Show ms for all judgments except 0.0ms"},
                         };
                         int mode = static_cast<int>(fast_slow_display::mode);
                         auto const& [mode_text, descriptive_text] = options[mode];

--- a/src/2dxtra/gui/main_window.cc
+++ b/src/2dxtra/gui/main_window.cc
@@ -344,7 +344,8 @@ namespace iidxtra::gui::main_window
                     {
                         auto const options = std::vector<std::tuple<std::string, std::string>> {
                             {"Off", "Use regular FAST/SLOW sprites"},
-                            {"<PGREAT", "Show ms for GREAT and below"},
+                            {"<PGREAT", "Show ms for GREAT & below"},
+                            {"<PGREAT+", "GREAT & below, shifted to be symmetric"},
                             {"Always", "Show ms for all judgments except 0.0ms"},
                         };
                         int mode = static_cast<int>(fast_slow_display::mode);
@@ -355,7 +356,7 @@ namespace iidxtra::gui::main_window
                             ImGui::Text("FAST/SLOW ms");
                             ImGui::SameLine(300);
                             ImGui::SetNextItemWidth(100);
-                            if (ImGui::SliderInt("##MillisecondFastSlow", &mode, 0, 2,
+                            if (ImGui::SliderInt("##MillisecondFastSlow", &mode, 0, 3,
                                                  mode_text.c_str(), ImGuiSliderFlags_AlwaysClamp))
                             {
                                 fast_slow_display::mode = static_cast<fast_slow_display::mode_t>(mode);

--- a/src/2dxtra/gui/main_window.cc
+++ b/src/2dxtra/gui/main_window.cc
@@ -340,32 +340,47 @@ namespace iidxtra::gui::main_window
                         ImGui::PopStyleVar();
                         ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f}, "Hide the flashing blue bar above the keys");
                     }
+                }
+
+                if (ImGui::CollapsingHeader("Timing", ImGuiTreeNodeFlags_DefaultOpen))
+                {
+                    ImGui::BeginDisabled();
+                    ImGui::TextWrapped("These options only affect FAST/SLOW indicators "
+                                       "and do not affect acutal timing or scoring");
+                    ImGui::EndDisabled();
 
                     {
-                        auto const options = std::vector<std::tuple<std::string, std::string>> {
-                            {"Off", "Use regular FAST/SLOW sprites"},
-                            {"<PGREAT", "Show ms for GREAT & below"},
-                            {"<PGREAT+", "GREAT & below, shifted to be symmetric"},
-                            {"Always", "Show ms for all judgments except 0.0ms"},
-                        };
-                        int mode = static_cast<int>(fast_slow_display::mode);
-                        auto const& [mode_text, descriptive_text] = options[mode];
                         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, -5.0f));
                         {
-                            ImGui::BeginDisabled(!fast_slow_hook::available() || bm2dx::play_session->in_gameplay);
-                            ImGui::Text("FAST/SLOW ms");
+                            ImGui::Text("Show Milliseconds");
                             ImGui::SameLine(300);
-                            ImGui::SetNextItemWidth(100);
-                            if (ImGui::SliderInt("##MillisecondFastSlow", &mode, 0, 3,
-                                                 mode_text.c_str(), ImGuiSliderFlags_AlwaysClamp))
-                            {
-                                fast_slow_display::mode = static_cast<fast_slow_display::mode_t>(mode);
+                            ImGui::BeginDisabled(!fast_slow_hook::available() ||
+                                                 bm2dx::play_session->in_gameplay);
+                            if (ImGui::Checkbox("##FastSlowMilliseconds",
+                                                &fast_slow_display::options.show_milliseconds))
                                 fast_slow_display::update();
-                            }
                             ImGui::EndDisabled();
                         }
                         ImGui::PopStyleVar();
-                        ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f}, "%s", descriptive_text.c_str());
+                        ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f},
+                                           "Show ms value instead of FAST/SLOW");
+                    }
+
+                    {
+                        ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, -5.0f));
+                        {
+                            ImGui::Text("Show FAST/SLOW for PGREAT");
+                            ImGui::SameLine(300);
+                            ImGui::BeginDisabled(!fast_slow_hook::available() ||
+                                                 bm2dx::play_session->in_gameplay);
+                            if (ImGui::Checkbox("##FastSlowPGREAT",
+                                                &fast_slow_display::options.show_pgreat))
+                                fast_slow_display::update();
+                            ImGui::EndDisabled();
+                        }
+                        ImGui::PopStyleVar();
+                        ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f},
+                                           "Requires 120Hz");
                     }
                 }
 

--- a/src/2dxtra/gui/main_window.cc
+++ b/src/2dxtra/gui/main_window.cc
@@ -342,17 +342,29 @@ namespace iidxtra::gui::main_window
                     }
 
                     {
+                        auto const options = std::vector<std::tuple<std::string, std::string>> {
+                            {"Off", "Use regular FAST/SLOW sprites"},
+                            {"<PGREAT", "Show milliseconds for GREAT and below"},
+                            {"Always", "Show milliseconds for all judgments except 0.0ms"},
+                        };
+                        int mode = static_cast<int>(fast_slow_display::mode);
+                        auto const& [mode_text, descriptive_text] = options[mode];
                         ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0.0f, -5.0f));
                         {
                             ImGui::BeginDisabled(!fast_slow_hook::available() || bm2dx::play_session->in_gameplay);
                             ImGui::Text("FAST/SLOW ms");
                             ImGui::SameLine(300);
-                            if (ImGui::Checkbox("##MillisecondFastSlow", &fast_slow_display::enabled))
+                            ImGui::SetNextItemWidth(100);
+                            if (ImGui::SliderInt("##MillisecondFastSlow", &mode, 0, 2,
+                                                 mode_text.c_str(), ImGuiSliderFlags_AlwaysClamp))
+                            {
+                                fast_slow_display::mode = static_cast<fast_slow_display::mode_t>(mode);
                                 fast_slow_display::update();
+                            }
                             ImGui::EndDisabled();
                         }
                         ImGui::PopStyleVar();
-                        ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f}, "Replace FAST/SLOW with millisecond values");
+                        ImGui::TextColored({0.5f, 0.5f, 0.5f, 1.f}, "%s", descriptive_text.c_str());
                     }
                 }
 

--- a/src/2dxtra/hooks/fast_slow_hook.cc
+++ b/src/2dxtra/hooks/fast_slow_hook.cc
@@ -7,6 +7,7 @@
 #include <intrin.h>
 #endif
 #include "../game.h"
+#include "../judgment.h"
 #include "../features/fast_slow_display.h"
 #include "fast_slow_hook.h"
 
@@ -86,13 +87,18 @@ namespace iidxtra::fast_slow_hook
     // Shared timing and enable state are accessed from both game hooks and the menu.
     auto state_mutex = std::mutex {};
     auto cache = fast_slow_display::display_cache_t {};
-    auto display_enabled = false;
+    auto display_mode = fast_slow_display::mode_t::off;
     auto installed = false;
+
+    auto get_mode() -> fast_slow_display::mode_t
+    {
+        const auto lock = std::lock_guard { state_mutex };
+        return display_mode;
+    }
 
     auto is_enabled() -> bool
     {
-        const auto lock = std::lock_guard { state_mutex };
-        return display_enabled;
+        return get_mode() != fast_slow_display::mode_t::off;
     }
 
     // Stores the pending judgment for next draw call.
@@ -109,7 +115,7 @@ namespace iidxtra::fast_slow_hook
     {
         timing_t timing;
         std::array<char, 7> text {};
-        bool miss = false;
+        bool word_label = false;
     };
     thread_local auto rendering = render_context_t {};
 
@@ -167,17 +173,36 @@ namespace iidxtra::fast_slow_hook
         {
             const auto& addresses = *bm2dx::addr;
 
-            if (is_enabled() &&
-                player >= 0 && player < 2 &&
-                lane >= 0 && lane < 8 &&
-                grade >= 0 && grade <= 8 &&
-                (caller == addresses.JUDGE_PRESS_RETURN || caller == addresses.JUDGE_RELEASE_RETURN))
+            const bool capture_enabled = is_enabled();
+            const bool valid_note = player >= 0 && player < 2 && lane >= 0 && lane < 8;
+            const bool is_press = caller == addresses.JUDGE_PRESS_RETURN;
+            const bool is_release = caller == addresses.JUDGE_RELEASE_RETURN;
+
+            if (capture_enabled && valid_note && (is_press || is_release))
             {
                 // read the candidate judgment context for this lane and player
                 const auto candidate = read<judge_apply_hook_context_t>(
                     context, sizeof(judge_apply_hook_context_t) * (lane + 8 * player));
                 if (candidate.note)
-                    pending = { player, lane == 7, { candidate.milliseconds } };
+                {
+                    const bool is_scratch = lane == 7;
+
+                    // note+24 is a flag that tells us if the note has not been judged
+                    // if it was already judged (0) then this is an excessive poor
+                    // the game engine would normally display SLOW for this and generate +250ms
+                    // as a placeholder but showing that ms value would be misleading; therefore
+                    // we do a special case for this (show "poor")
+                    const bool excessive_poor = is_press &&
+                        grade == bm2dx::judge_grade::late_poor &&
+                        read<std::uint8_t>(candidate.note, 24) == 0;
+
+                    pending =
+                    {
+                        player,
+                        is_scratch,
+                        { candidate.milliseconds, excessive_poor }
+                    };
+                }
             }
 
             // call into the original judgment apply function
@@ -202,7 +227,8 @@ namespace iidxtra::fast_slow_hook
 
         const auto lock = std::lock_guard { state_mutex };
         auto timing = timing_t {};
-        if (display_enabled && pending.player == player && pending.scratch == scratch)
+        if (display_mode != fast_slow_display::mode_t::off &&
+            pending.player == player && pending.scratch == scratch)
             timing = pending.timing;
 
         cache.update(player, reinterpret_cast<std::uintptr_t>(display), code, scratch, timing);
@@ -219,7 +245,8 @@ namespace iidxtra::fast_slow_hook
         try
         {
             // if the feature is disabled, call the original
-            if (!is_enabled())
+            const auto mode = get_mode();
+            if (mode == fast_slow_display::mode_t::off)
             {
                 original(display);
                 rendering = saved_rendering;
@@ -238,16 +265,29 @@ namespace iidxtra::fast_slow_hook
                     displayed_code = &local_display.key_code;
 
                 const auto code = *displayed_code;
+                if (mode == fast_slow_display::mode_t::great_and_below &&
+                    code == bm2dx::judge_display_code::pgreat)
+                {
+                    rendering = saved_rendering;
+                    return;
+                }
+
                 {
                     const auto lock = std::lock_guard { state_mutex };
                     rendering.timing = cache.get(local_display.player, reinterpret_cast<std::uintptr_t>(display),
                                                  separate, scratch);
                 }
 
-                if (code == 8)
+                if (code == bm2dx::judge_display_code::miss && rendering.timing.excessive_poor)
                 {
-                    // For complete misses, display 'miss'.
-                    rendering.miss = true;
+                    rendering.word_label = true;
+                    rendering.text = { 'p', 'o', 'o', 'r', '\0' };
+                }
+                else if (code == bm2dx::judge_display_code::miss &&
+                    rendering.timing.get_polarity() == polarity::zero)
+                {
+                    // For misses without measured timing, display 'miss'.
+                    rendering.word_label = true;
                     rendering.timing = {};
                     rendering.text = { 'm', 'i', 's', 's', '\0' };
                 }
@@ -257,12 +297,13 @@ namespace iidxtra::fast_slow_hook
                     rendering.text = fast_slow_display::format_fastslow_ms(rendering.timing.milliseconds);
                 }
 
-                if (code == 4 && rendering.text[0] != '\0')
+                if (code == bm2dx::judge_display_code::pgreat && rendering.text[0] != '\0')
                 {
                     // Code 4 (PGREAT) normally emits no FAST/SLOW sprite for us to replace.
                     // Change only our copy to code 3 (FAST) or 5 (SLOW), making the native draw
                     // function emit that sprite while leaving the game's real PGREAT untouched.
-                    *displayed_code = rendering.timing.get_polarity() == polarity::slow ? 5 : 3;
+                    *displayed_code = rendering.timing.get_polarity() == polarity::slow ?
+                        bm2dx::judge_display_code::late_great : bm2dx::judge_display_code::early_great;
                     pgreat = true;
                 }
             }
@@ -317,7 +358,7 @@ namespace iidxtra::fast_slow_hook
 
     auto draw_text(int horizontal, int vertical, const unsigned int layer, const char* text,
                    const int width, const int height, const bool fast, const bool scratch,
-                   const bool miss) -> void
+                   const bool word_label) -> void
     {
         // Font 3 is DFG Heisei Gothic W7 at 16 pixels, also used by bottom text like FREE PLAY.
         constexpr auto font = 3;
@@ -339,7 +380,7 @@ namespace iidxtra::fast_slow_hook
         init_text(&properties);
 
         auto content = std::string {};
-        if (miss)
+        if (word_label)
         {
             // Center the whole word in the sprite area, with all letters on a shared baseline.
             properties.h_align = 1;
@@ -408,7 +449,7 @@ namespace iidxtra::fast_slow_hook
         auto height = 0;
         get_dimensions(sprite, &width, &height);
         draw_text(horizontal, vertical, layer, rendering.text.data(), width, height,
-                  rendering.timing.get_polarity() == polarity::fast, asset.starts_with("s_"), rendering.miss);
+                  rendering.timing.get_polarity() == polarity::fast, asset.starts_with("s_"), rendering.word_label);
 
         return sprite;
     }
@@ -420,10 +461,10 @@ namespace iidxtra::fast_slow_hook
         return installed;
     }
 
-    auto set_enabled(const bool value) -> void
+    auto set_mode(const fast_slow_display::mode_t value) -> void
     {
         const auto lock = std::lock_guard { state_mutex };
-        display_enabled = installed && value;
+        display_mode = installed ? value : fast_slow_display::mode_t::off;
         cache = {};
     }
 

--- a/src/2dxtra/hooks/fast_slow_hook.cc
+++ b/src/2dxtra/hooks/fast_slow_hook.cc
@@ -1,5 +1,6 @@
 #include <MinHook.h>
 #include <fmt/format.h>
+#include <cmath>
 #include <cstring>
 #include <mutex>
 #include <string_view>
@@ -13,14 +14,14 @@
 
 namespace iidxtra::fast_slow_hook
 {
-    // Replace FAST/SLOW sprites with millisecond text rendered by us:
+    // Customize FAST/SLOW indicators without changing the game's judgments:
     //
     // 1. judge_apply_hook_fn captures the millisecond timing value.
     // 2. judge_display_hook_fn updates our stored timing to match the game's judgment.
     // 3. judge_draw_fs_keys_hook_fn & judge_draw_fs_sc_hook_fn call draw_indicator
-    //    to prepare the timing text, then call the game's original draw function.
-    // 4. sprite_draw_hook_fn receives the sprite's x/y coordinates, hides the
-    //    FAST/SLOW sprite, and draws our text in its place.
+    //    to prepare the display direction and optional timing text.
+    // 4. When milliseconds are enabled, sprite_draw_hook_fn receives the sprite's
+    //    x/y coordinates, hides the FAST/SLOW sprite, and draws our text in its place.
 
     using fast_slow_display::polarity;
     using fast_slow_display::timing_t;
@@ -90,18 +91,13 @@ namespace iidxtra::fast_slow_hook
     // Shared timing and enable state are accessed from both game hooks and the menu.
     auto state_mutex = std::mutex {};
     auto cache = fast_slow_display::display_cache_t {};
-    auto display_mode = fast_slow_display::mode_t::off;
+    auto display_options = fast_slow_display::options_t {};
     auto installed = false;
 
-    auto get_mode() -> fast_slow_display::mode_t
+    auto get_options() -> fast_slow_display::options_t
     {
         const auto lock = std::lock_guard { state_mutex };
-        return display_mode;
-    }
-
-    auto is_enabled() -> bool
-    {
-        return get_mode() != fast_slow_display::mode_t::off;
+        return display_options;
     }
 
     // Stores the pending judgment for next draw call.
@@ -158,6 +154,33 @@ namespace iidxtra::fast_slow_hook
         return original_judge_display_init_fn(display, player, mode);
     }
 
+    auto prepare_timing(const float milliseconds, const int ticks, const bool excessive_poor,
+                        const fast_slow_display::options_t& options) -> timing_t
+    {
+        auto timing = timing_t {
+            .milliseconds = milliseconds,
+            .excessive_poor = excessive_poor,
+            .measured = !excessive_poor && std::isfinite(milliseconds),
+            .within_dead_zone = ticks == 0 || ticks == 1
+        };
+
+        // Use the game's measured tick rate to shift everything by half a tick
+        // when displaying millisecond timing windows. This is needed because
+        // the game is tick-based, which means on 120Hz PGREAT is [-1, 0, 1, 2]
+        // ticks where tick 0 is the 0.0ms window. This gives us asymmetric
+        // timing values which would confuse the playe; shifting values by half
+        // a tick fixes that.
+        if (options.show_milliseconds && timing.measured && bm2dx::config)
+        {
+            const float tick_rate = bm2dx::config->monitor_check_fps;
+            // Being really defensive here due to various timing patches
+            if (std::isfinite(tick_rate) && tick_rate > 0.0f)
+                timing.milliseconds -= (1000.0f / tick_rate) * 0.5f;
+        }
+
+        return timing;
+    }
+
     // Timing value must be captured here, before the original call updates the display.
     auto judge_apply_hook_fn(void* context, const int player, const int grade,
                              const int lane, const int score_index) -> int
@@ -168,7 +191,6 @@ namespace iidxtra::fast_slow_hook
         const auto caller = static_cast<std::uint8_t*>(__builtin_return_address(0));
 #endif
 
-        // Load the saved pending value
         const auto saved_pending = pending;
         pending = {};
 
@@ -176,8 +198,8 @@ namespace iidxtra::fast_slow_hook
         {
             const auto& addresses = *bm2dx::addr;
 
-            const auto mode = get_mode();
-            const bool capture_enabled = mode != fast_slow_display::mode_t::off;
+            const auto options = get_options();
+            const bool capture_enabled = options.enabled();
             const bool valid_note = player >= 0 && player < 2 && lane >= 0 && lane < 8;
             const bool is_press = caller == addresses.JUDGE_PRESS_RETURN;
             const bool is_release = caller == addresses.JUDGE_RELEASE_RETURN;
@@ -200,24 +222,13 @@ namespace iidxtra::fast_slow_hook
                         grade == bm2dx::judge_grade::late_poor &&
                         read<std::uint8_t>(candidate.note, 24) == 0;
 
-                    // For Shifted mode, calculate "symmetric" timing value by shifting by half a tick
-                    // We compare the ms value to the tick value to accurately determine tick rate
-                    auto timing = timing_t { candidate.milliseconds, excessive_poor };
-                    if (mode == fast_slow_display::mode_t::great_and_below_shifted &&
-                        !excessive_poor && candidate.ticks != 0 &&
-                        timing.get_polarity() != polarity::zero)
-                    {
-                        const auto half_tick_ms = candidate.milliseconds /
-                            static_cast<float>(candidate.ticks) * 0.5f;
-                        if (half_tick_ms > 0.0f)
-                            timing.milliseconds -= half_tick_ms;
-                    }
-
                     pending =
                     {
                         player,
                         is_scratch,
-                        timing
+                        prepare_timing(candidate.milliseconds,
+                                       candidate.ticks,
+                                       excessive_poor, options)
                     };
                 }
             }
@@ -244,7 +255,7 @@ namespace iidxtra::fast_slow_hook
 
         const auto lock = std::lock_guard { state_mutex };
         auto timing = timing_t {};
-        if (display_mode != fast_slow_display::mode_t::off &&
+        if (display_options.enabled() &&
             pending.player == player && pending.scratch == scratch)
             timing = pending.timing;
 
@@ -252,8 +263,30 @@ namespace iidxtra::fast_slow_hook
         return result;
     }
 
-    // The game still decides whether and where to draw an indicator. We prepare the text here,
-    // then let its draw function reach sprite_draw_hook_fn with the native position and layer.
+    auto prepare_indicator_text(render_context_t& output, const int code) -> void
+    {
+        if (code == bm2dx::judge_display_code::miss && output.timing.excessive_poor)
+        {
+            output.word_label = true;
+            output.text = { 'p', 'o', 'o', 'r', '\0' };
+        }
+        else if (code == bm2dx::judge_display_code::miss &&
+            output.timing.get_polarity() == polarity::zero)
+        {
+            // For misses without measured timing, display 'miss'.
+            output.word_label = true;
+            output.timing = {};
+            output.text = { 'm', 'i', 's', 's', '\0' };
+        }
+        else
+        {
+            // Otherwise, format the text for millisecond timing.
+            output.text = fast_slow_display::format_fastslow_ms(output.timing.milliseconds);
+        }
+    }
+
+    // Prepare indicator visibility, direction and optional text without changing live judgments.
+    // The game's draw function retains the native position and layer.
     auto draw_indicator(void* display, const bool scratch, const draw_indicator_t original) -> void
     {
         const auto saved_rendering = rendering;
@@ -262,8 +295,8 @@ namespace iidxtra::fast_slow_hook
         try
         {
             // if the feature is disabled, call the original
-            const auto mode = get_mode();
-            if (mode == fast_slow_display::mode_t::off)
+            const auto options = get_options();
+            if (!options.enabled())
             {
                 original(display);
                 rendering = saved_rendering;
@@ -271,7 +304,7 @@ namespace iidxtra::fast_slow_hook
             }
 
             auto local_display = read<judge_display_hook_context_t>(display);
-            auto pgreat = false;
+            void* draw_display = display;
             if (local_display.player >= 0 && local_display.player < 2)
             {
                 const auto separate = separate_scratch(local_display.player);
@@ -282,9 +315,7 @@ namespace iidxtra::fast_slow_hook
                     displayed_code = &local_display.key_code;
 
                 const auto code = *displayed_code;
-                 if ((mode == fast_slow_display::mode_t::great_and_below ||
-                     mode == fast_slow_display::mode_t::great_and_below_shifted) &&
-                    code == bm2dx::judge_display_code::pgreat)
+                if (!options.show_pgreat && code == bm2dx::judge_display_code::pgreat)
                 {
                     rendering = saved_rendering;
                     return;
@@ -292,58 +323,44 @@ namespace iidxtra::fast_slow_hook
 
                 {
                     const auto lock = std::lock_guard { state_mutex };
-                    rendering.timing = cache.get(local_display.player, reinterpret_cast<std::uintptr_t>(display),
-                                                 separate, scratch);
+                    rendering.timing = cache.get(local_display.player,
+                        reinterpret_cast<std::uintptr_t>(display), separate, scratch);
                 }
 
-                if (code == bm2dx::judge_display_code::miss && rendering.timing.excessive_poor)
+                // excessive poors are "not measured",
+                // among other error cases where there is no associated note with judgment
+                const bool measured = rendering.timing.measured;
+                const auto direction = rendering.timing.get_polarity();
+                if ((options.show_pgreat && measured && rendering.timing.within_dead_zone) || // within 1 frame
+                    (options.show_milliseconds && measured && direction == polarity::zero) || // 0.0ms
+                    (code == bm2dx::judge_display_code::pgreat && !measured))
                 {
-                    rendering.word_label = true;
-                    rendering.text = { 'p', 'o', 'o', 'r', '\0' };
-                }
-                else if (code == bm2dx::judge_display_code::miss &&
-                    rendering.timing.get_polarity() == polarity::zero)
-                {
-                    // For misses without measured timing, display 'miss'.
-                    rendering.word_label = true;
-                    rendering.timing = {};
-                    rendering.text = { 'm', 'i', 's', 's', '\0' };
-                }
-                else
-                {
-                    // Otherwise, format the text for millisecond timing.
-                    rendering.text = fast_slow_display::format_fastslow_ms(rendering.timing.milliseconds);
+                    rendering = saved_rendering;
+                    return;
                 }
 
-                if (code == bm2dx::judge_display_code::pgreat && rendering.text[0] != '\0')
+                if (options.show_milliseconds)
+                    prepare_indicator_text(rendering, code);
+
+                if (measured && direction != polarity::zero &&
+                    code >= bm2dx::judge_display_code::early_poor &&
+                    code <= bm2dx::judge_display_code::miss)
                 {
-                    // Code 4 (PGREAT) normally emits no FAST/SLOW sprite for us to replace.
-                    // Change only our copy to code 3 (FAST) or 5 (SLOW), making the native draw
-                    // function emit that sprite while leaving the game's real PGREAT untouched.
-                    *displayed_code = rendering.timing.get_polarity() == polarity::slow ?
+                    // A display-only code selects the adjusted direction and enables PGREAT
+                    // indicators while leaving the game's real judgment untouched.
+                    *displayed_code = direction == polarity::slow ?
                         bm2dx::judge_display_code::late_great : bm2dx::judge_display_code::early_great;
-                    pgreat = true;
+                    draw_display = &local_display;
                 }
             }
 
-            if (rendering.text[0] == '\0')
+            if (options.show_milliseconds && rendering.text[0] == '\0')
             {
                 rendering = saved_rendering;
                 return;
             }
 
-            if (pgreat)
-            {
-                // Call the original but convince it to still display f/s indicator even for pgreat
-                original(&local_display);
-            }
-            else
-            {
-                // Call the original.
-                original(display);
-            }
-
-            // Restore the original rendering state.
+            original(draw_display);
             rendering = saved_rendering;
         }
         catch (...)
@@ -479,10 +496,10 @@ namespace iidxtra::fast_slow_hook
         return installed;
     }
 
-    auto set_mode(const fast_slow_display::mode_t value) -> void
+    auto set_options(const fast_slow_display::options_t value) -> void
     {
         const auto lock = std::lock_guard { state_mutex };
-        display_mode = installed ? value : fast_slow_display::mode_t::off;
+        display_options = installed ? value : fast_slow_display::options_t {};
         cache = {};
     }
 

--- a/src/2dxtra/hooks/fast_slow_hook.cc
+++ b/src/2dxtra/hooks/fast_slow_hook.cc
@@ -30,11 +30,14 @@ namespace iidxtra::fast_slow_hook
     {
         // timing value in milliseconds
         float milliseconds;
-        std::byte reserved_04[4];
+        // Tick value for judge; negative is early, positive is late
+        // with default timing windows, PGREATS are [0, 1] on 60Hz LDJ, [-1, 2] on TDJ
+        std::int32_t ticks;
         // pointer to in-game note; used to check if judgement is valid (has note)
         void* note;
     };
     static_assert(sizeof(judge_apply_hook_context_t) == 16);
+    static_assert(offsetof(judge_apply_hook_context_t, ticks) == 4);
     static_assert(offsetof(judge_apply_hook_context_t, note) == 8);
 
     // context object passed to judge_display_hook_fn.
@@ -173,7 +176,8 @@ namespace iidxtra::fast_slow_hook
         {
             const auto& addresses = *bm2dx::addr;
 
-            const bool capture_enabled = is_enabled();
+            const auto mode = get_mode();
+            const bool capture_enabled = mode != fast_slow_display::mode_t::off;
             const bool valid_note = player >= 0 && player < 2 && lane >= 0 && lane < 8;
             const bool is_press = caller == addresses.JUDGE_PRESS_RETURN;
             const bool is_release = caller == addresses.JUDGE_RELEASE_RETURN;
@@ -196,11 +200,24 @@ namespace iidxtra::fast_slow_hook
                         grade == bm2dx::judge_grade::late_poor &&
                         read<std::uint8_t>(candidate.note, 24) == 0;
 
+                    // For Shifted mode, calculate "symmetric" timing value by shifting by half a tick
+                    // We compare the ms value to the tick value to accurately determine tick rate
+                    auto timing = timing_t { candidate.milliseconds, excessive_poor };
+                    if (mode == fast_slow_display::mode_t::great_and_below_shifted &&
+                        !excessive_poor && candidate.ticks != 0 &&
+                        timing.get_polarity() != polarity::zero)
+                    {
+                        const auto half_tick_ms = candidate.milliseconds /
+                            static_cast<float>(candidate.ticks) * 0.5f;
+                        if (half_tick_ms > 0.0f)
+                            timing.milliseconds -= half_tick_ms;
+                    }
+
                     pending =
                     {
                         player,
                         is_scratch,
-                        { candidate.milliseconds, excessive_poor }
+                        timing
                     };
                 }
             }
@@ -265,7 +282,8 @@ namespace iidxtra::fast_slow_hook
                     displayed_code = &local_display.key_code;
 
                 const auto code = *displayed_code;
-                if (mode == fast_slow_display::mode_t::great_and_below &&
+                 if ((mode == fast_slow_display::mode_t::great_and_below ||
+                     mode == fast_slow_display::mode_t::great_and_below_shifted) &&
                     code == bm2dx::judge_display_code::pgreat)
                 {
                     rendering = saved_rendering;

--- a/src/2dxtra/hooks/fast_slow_hook.h
+++ b/src/2dxtra/hooks/fast_slow_hook.h
@@ -6,5 +6,5 @@ namespace iidxtra::fast_slow_hook
 {
     auto install_hook() -> void;
     auto available() -> bool;
-    auto set_mode(fast_slow_display::mode_t value) -> void;
+    auto set_options(fast_slow_display::options_t value) -> void;
 }

--- a/src/2dxtra/hooks/fast_slow_hook.h
+++ b/src/2dxtra/hooks/fast_slow_hook.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "../features/fast_slow_display.h"
+
 namespace iidxtra::fast_slow_hook
 {
     auto install_hook() -> void;
     auto available() -> bool;
-    auto set_enabled(bool value) -> void;
+    auto set_mode(fast_slow_display::mode_t value) -> void;
 }

--- a/src/2dxtra/judgment.h
+++ b/src/2dxtra/judgment.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace bm2dx::judge_grade
+{
+    constexpr int early_poor = 0;
+    constexpr int early_bad = 1;
+    constexpr int early_good = 2;
+    constexpr int early_great = 3;
+    constexpr int early_pgreat = 4;
+    constexpr int late_pgreat = 5;
+    constexpr int late_great = 6;
+    constexpr int late_good = 7;
+    constexpr int late_bad = 8;
+    constexpr int late_poor = 9;
+}
+
+namespace bm2dx::judge_display_code
+{
+    // Display codes merge the two PGREAT grades and several POOR variants.
+    constexpr int early_poor = 0;
+    constexpr int early_bad = 1;
+    constexpr int early_good = 2;
+    constexpr int early_great = 3;
+    constexpr int pgreat = 4;
+    constexpr int late_great = 5;
+    constexpr int late_good = 6;
+    constexpr int late_bad = 7;
+    constexpr int miss = 8;
+    constexpr int charge_hold = 12;
+}


### PR DESCRIPTION
- Introduce constants for judge window and judge display values used by the game.
- For millisecond display, shift by half a tick to show "true" offset (as opposed to asymmetric values used internally by the game)
- Add new checkbox option for showing F/S for `PGREAT` (unless frame-perfect in ticks 0 or 1). Can be enabled independently of the millisecond option.
- Add specific handling for excessive POORs (shows `poor` instead of `slow`)
- Add specific handling for early release of CN (shows millisecond value instead of `fast`). Game engine tells you how early the button was released, which can be more than 1s; in that case cap the display to `999.9ms`.